### PR TITLE
Cleaned up code

### DIFF
--- a/NoItemDrop/src/me/noodles/nodrop/Event.java
+++ b/NoItemDrop/src/me/noodles/nodrop/Event.java
@@ -8,14 +8,9 @@ import org.bukkit.event.player.PlayerDropItemEvent;
 
 public class Event implements Listener {
 
-	
-	
 	  @EventHandler
 	  public void onThrow(PlayerDropItemEvent e)
 	  {
-	    Player player = e.getPlayer();
-	    if (!player.hasPermission("drop.allow"))  {
-	    e.setCancelled(true);
-	    }
+		  event.setCancelled(!event.getPlayer().hasPermission("drop.allow"));
 	  }
 	}

--- a/NoItemDrop/src/me/noodles/nodrop/Event.java
+++ b/NoItemDrop/src/me/noodles/nodrop/Event.java
@@ -11,6 +11,6 @@ public class Event implements Listener {
 	  @EventHandler
 	  public void onThrow(PlayerDropItemEvent e)
 	  {
-		  event.setCancelled(!event.getPlayer().hasPermission("drop.allow"));
+		  event.setCancelled(!e.getPlayer().hasPermission("drop.allow"));
 	  }
 	}


### PR DESCRIPTION
Since you only reference player once, you don't really need to cast it. This change just returns true / false on if the user doesn't have the permission node and that returned variable (true / false) is used in the cancel method so that you can keep it clean and all in a single line. Hope this was helpful.